### PR TITLE
Add the ability to compile to a string

### DIFF
--- a/examples/compileHelloWorld.js
+++ b/examples/compileHelloWorld.js
@@ -8,10 +8,10 @@ compile(["./HelloWorld.elm"], {
 });
 
 
-compileToString(["./HelloWorld.elm"], { yes: true }, function(err, data){
+compileToString(["./HelloWorld.elm"], { yes: true }).then(function(data){
     console.log("Text", data.toString());
 });
 
-compileToString(["./HelloWorld.elm"], { yes: true, output: "index.html" }, function(err, data){
+compileToString(["./HelloWorld.elm"], { yes: true, output: "index.html" }).then(function(data){
     console.log("Text", data.toString());
 });

--- a/examples/compileHelloWorld.js
+++ b/examples/compileHelloWorld.js
@@ -1,7 +1,17 @@
 var compile = require("../index.js").compile;
+var compileToString = require("../index.js").compileToString;
 
 compile(["./HelloWorld.elm"], {
   output: "compiled-hello-world.js"
 }).on('close', function(exitCode) {
   console.log("Finished with exit code", exitCode);
+});
+
+
+compileToString(["./HelloWorld.elm"], { yes: true }, function(err, data){
+    console.log("Text", data.toString());
+});
+
+compileToString(["./HelloWorld.elm"], { yes: true, output: "index.html" }, function(err, data){
+    console.log("Text", data.toString());
 });

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "chai": "3.4.1",
-    "mocha": "2.3.4"
+    "mocha": "2.3.4",
+    "temp": "^0.8.3"
   }
 }


### PR DESCRIPTION
# What I added

An exported function that sends compiled Elm code out as a string. The api matches with the current one for compile, except there's also a `callback` which will take any errors and the data returned as a buffer.

I also added two examples for this

options.output will be used to figure out if we want to compile to html or js. For example, js would be `main.js`. html would be `index.html

# Motivation

I needed this for `elm-webpack` so that we didn't need to create real files, just get text back. 