### PR TITLE
Simplify `npm test` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Node.js interface to the Elm compiler binaries. Supports Elm versions 0.15 - 0.16.",
   "main": "index.js",
   "scripts": {
-    "test": "cd test/fixtures && elm-package install --yes && cd ../.. && mocha test/*.js"
+    "test": "mocha test/*.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Doing the `elm-package install` up front is probably not necessary given that the timeout for the individual tests needs to be ridiculously long for Travis anyway.