### PR TITLE
Test compilation of bad sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,6 +164,10 @@ function compileToString(sources, options){
       compile(sources, options)
         .on("close", function(exitCode){
           fs.readFile(info.path, function(err, data){
+            if (exitCode !== 0) {
+              err = "Compiler process exited with code " + exitCode;
+            }
+
             temp.cleanupSync();
 
             return err ? reject(err) : resolve(data);

--- a/test/compile.js
+++ b/test/compile.js
@@ -11,10 +11,10 @@ function prependFixturesDir(filename) {
 }
 
 describe("#compile", function() {
-  it("works with --yes", function (done) {
-    // Use a timeout of 5 minutes because Travis on Linux can be SUPER slow.
-    this.timeout(300000);
+  // Use a timeout of 5 minutes because Travis on Linux can be SUPER slow.
+  this.timeout(300000);
 
+  it("works with --yes", function (done) {
     var opts = {yes: true, output: "/dev/null", verbose: true, cwd: fixturesDir};
     var compileProcess = compiler.compile(prependFixturesDir("Parent.elm"), opts);
 
@@ -23,18 +23,38 @@ describe("#compile", function() {
       done();
     });
   });
+
+  it("reports errors on bad source", function (done) {
+    var opts = {yes: true, verbose: true, cwd: fixturesDir};
+    var compileProcess = compiler.compile(prependFixturesDir("Bad.elm"), opts);
+
+    compileProcess.on("exit", function(exitCode) {
+      assert.equal(exitCode, 1, "Expected elm-make to have exit code 1");
+      done();
+    });
+  });
 });
 
 describe("#compileToString", function() {
-  it("works with --yes", function (done) {
-    // Use a timeout of 5 minutes because Travis on Linux can be SUPER slow.
-    this.timeout(300000);
+  // Use a timeout of 5 minutes because Travis on Linux can be SUPER slow.
+  this.timeout(300000);
 
+  it("works with --yes", function (done) {
     var opts = {yes: true, verbose: true, cwd: fixturesDir};
     var compilePromise = compiler.compileToString(prependFixturesDir("Parent.elm"), opts);
 
     compilePromise.then(function(result) {
       assert.isString(result.toString(), "Expected elm-make to return the result of the compilation");
+      done();
+    });
+  });
+
+  it("reports errors on bad source", function (done) {
+    var opts = {yes: true, verbose: true, cwd: fixturesDir};
+    var compilePromise = compiler.compileToString(prependFixturesDir("Bad.elm"), opts);
+
+    compilePromise.catch(function(err) {
+      assert.equal(err, "Compiler process exited with code 1", "Expected elm-make to have exit code 1");
       done();
     });
   });

--- a/test/fixtures/Bad.elm
+++ b/test/fixtures/Bad.elm
@@ -1,0 +1,7 @@
+module Bad (..) where
+
+import Graphics.Element exposing (show)
+
+
+main =
+    show "Hello, World!


### PR DESCRIPTION
Added tests for bad sources, as I saw an issue with the new `compileToString` method incorrectly resolving when it should reject.