### PR TITLE
Adding `compilerIO` flag to set subproc STDIO

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function compile(sources, options) {
   var compilerArgs = compilerArgsFromOptions(options, options.emitWarning);
   var processArgs  = sources ? sources.concat(compilerArgs) : compilerArgs;
   var env = _.merge({LANG: 'en_US.UTF-8'}, process.env);
-  var processOpts = _.merge({env: env, stdio: options.compilerIO, cwd: options.cwd});
+  var processOpts = {env: env, stdio: options.compilerIO, cwd: options.cwd};
   var pathToMake = options.pathToMake || compilerBinaryName;
   var verbose = options.verbose;
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var temp = require("temp");
 var defaultOptions     = {
   emitWarning: console.warn,
   spawn:      spawn,
+  compilerIO: "inherit",
   cwd:        undefined,
   pathToMake: undefined,
   yes:        undefined,
@@ -40,7 +41,7 @@ function compile(sources, options) {
   var compilerArgs = compilerArgsFromOptions(options, options.emitWarning);
   var processArgs  = sources ? sources.concat(compilerArgs) : compilerArgs;
   var env = _.merge({LANG: 'en_US.UTF-8'}, process.env);
-  var processOpts = _.merge({env: env, stdio: "inherit", cwd: options.cwd});
+  var processOpts = _.merge({env: env, stdio: options.compilerIO, cwd: options.cwd});
   var pathToMake = options.pathToMake || compilerBinaryName;
   var verbose = options.verbose;
 

--- a/index.js
+++ b/index.js
@@ -9,15 +9,15 @@ var temp = require("temp");
 
 var defaultOptions     = {
   emitWarning: console.warn,
-  spawn:      spawn,
-  compilerIO: "inherit",
-  cwd:        undefined,
-  pathToMake: undefined,
-  yes:        undefined,
-  help:       undefined,
-  output:     undefined,
-  warn:       undefined,
-  verbose:    false
+  spawn:       spawn,
+  compilerIO:  "inherit",
+  cwd:         undefined,
+  pathToMake:  undefined,
+  yes:         undefined,
+  help:        undefined,
+  output:      undefined,
+  warn:        undefined,
+  verbose:     false
 };
 
 var supportedOptions = _.keys(defaultOptions);

--- a/test/compile.js
+++ b/test/compile.js
@@ -61,6 +61,26 @@ describe("#compile", function() {
       done();
     });
   });
+
+  it("captures compiler IO when piped", function(done) {
+    var opts = {
+      yes: true,
+      verbose: true,
+      cwd: fixturesDir,
+      compilerIO: 'pipe'
+    };
+    var stderrSpy = chai.spy();
+
+    var compileProcess = compiler.compile(prependFixturesDir("Bad.elm"), opts);
+
+    compileProcess.stderr.on("data", stderrSpy);
+
+    compileProcess.on("exit", function(exitCode) {
+      var desc = "Expected STDERR to have been captured";
+      expect(stderrSpy, desc).to.have.been.called();
+      done();
+    });
+  });
 });
 
 describe("#compileToString", function() {


### PR DESCRIPTION
## The Change
Currently the option for STDIO is coded to be `inherit`, which is a good
default for most use cases.  However, sometimes a consumer would like to
capture the STDIO for processing or analysis, so adding this flag allows
them to pass `pipe` to capture, or `ignore` to discard the STDIO
altogether.

## Use Cases
- Capturing output for usage with on-screen printing in web apps
- Processing compiler errors for analytics of common compiler errors
- Silencing STDIO from sub-proc in unit tests by choosing `ignore` for `compilerIO`

## Extra Information
I cleaned up the alignment change from the previous `emitWarning` addition
and removed an extra `_.merge` in separate commits in case you'd prefer
either change reversed quickly.  I can rebase them to your preferred style
if it differs from what is here.  Thanks!