### PR TITLE
Use source-directories from elm-package.json to watch subdirs

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,10 +160,12 @@ function checkSourceDirs(baseDir, newImport) {
     var newFile = path.join(dir, newImport.replace(newBase, ''));
     return new Promise(function(resolve, reject) {
       checkIsFile(newFile + ".elm").then(function(file) {
-        resolve(file[0])
+        resolve(file[0]);
       }).catch(function(err) {
         if (err.code === "ENOENT") {
           resolve('');
+        } else {
+          reject(err);
         }
       });
     });


### PR DESCRIPTION
This solves https://github.com/rtfeldman/elm-webpack-loader/issues/35 if you have your `elm-package.json` in your root

It's not super pretty I guess, but maybe you can use this and make it better