### PR TITLE
Include error details in exception

### DIFF
--- a/test/compile.js
+++ b/test/compile.js
@@ -81,7 +81,7 @@ describe("#compileToString", function() {
     });
   });
 
-  it("reports errors on bad source", function () {
+  it("reports errors on bad syntax", function () {
     var opts = {
       yes: true,
       verbose: true,
@@ -90,8 +90,26 @@ describe("#compileToString", function() {
     var compilePromise = compiler.compileToString(prependFixturesDir("Bad.elm"), opts);
 
     return compilePromise.catch(function(err) {
-      var desc = "Expected elm-make to have exit code 1";
-      expect(err, desc).to.equal("Compiler process exited with code 1");
+      expect(err).to.be.an('error');
+      expect(String(err))
+        .to.contain("Compilation failed")
+        .and.contain("I ran into something unexpected when parsing your code!");
+    });
+  });
+
+  it("reports type errors", function () {
+    var opts = {
+      yes: true,
+      verbose: true,
+      cwd: fixturesDir
+    };
+    var compilePromise = compiler.compileToString(prependFixturesDir("TypeError.elm"), opts);
+
+    return compilePromise.catch(function(err) {
+      expect(err).to.be.an('error');
+      expect(String(err))
+        .to.contain("Compilation failed")
+        .and.contain("is causing a type mismatch");
     });
   });
 

--- a/test/compile.js
+++ b/test/compile.js
@@ -67,7 +67,7 @@ describe("#compileToString", function() {
   // Use a timeout of 5 minutes because Travis on Linux can be SUPER slow.
   this.timeout(3000);
 
-  it("works with --yes", function (done) {
+  it("works with --yes", function () {
     var opts = {
       yes: true,
       verbose: true,
@@ -75,14 +75,13 @@ describe("#compileToString", function() {
     };
     var compilePromise = compiler.compileToString(prependFixturesDir("Parent.elm"), opts);
 
-    compilePromise.then(function(result) {
+    return compilePromise.then(function(result) {
       var desc = "Expected elm-make to return the result of the compilation";
       expect(result.toString(), desc).to.be.a('string');
-      done();
     });
   });
 
-  it("reports errors on bad source", function (done) {
+  it("reports errors on bad source", function () {
     var opts = {
       yes: true,
       verbose: true,
@@ -90,14 +89,13 @@ describe("#compileToString", function() {
     };
     var compilePromise = compiler.compileToString(prependFixturesDir("Bad.elm"), opts);
 
-    compilePromise.catch(function(err) {
+    return compilePromise.catch(function(err) {
       var desc = "Expected elm-make to have exit code 1";
       expect(err, desc).to.equal("Compiler process exited with code 1");
-      done();
     });
   });
 
-  it("invokes custom `emitWarning`", function (done) {
+  it("invokes custom `emitWarning`", function () {
     var opts = {
       foo: "bar",
       emitWarning: chai.spy(),
@@ -107,10 +105,9 @@ describe("#compileToString", function() {
     };
     var compilePromise = compiler.compileToString(prependFixturesDir("Parent.elm"), opts);
 
-    compilePromise.then(function(err) {
+    return compilePromise.then(function(err) {
       var desc = "Expected emitWarning to have been called";
       expect(opts.emitWarning, desc).to.have.been.called();
-      done();
     });
   });
 });

--- a/test/fixtures/TypeError.elm
+++ b/test/fixtures/TypeError.elm
@@ -1,0 +1,7 @@
+module TypeError (..) where
+
+import Graphics.Element exposing (show)
+
+
+main =
+  show (1 ++ "2")


### PR DESCRIPTION
I'm not sure this PR is quite tidy enough to merge, but I wanted to open it for some discussion.

I set up my system to use `webpack-hot-middleware` along with `elm-loader` and `elm-hot-loader`, Hot middleware has an enhanced client which can show build errors in-page in an overlay. The current implementation didn't provide an error object from `compileToString` that worked with this.

This PR changes the error result to be an `Error` object, and populates it with the output from `elm-make`. Annoyingly, because this is no longer a tty, we lose colour (see https://github.com/elm-lang/elm-make/issues/73)

Here's what the changes look like in action:
![screen shot 2016-05-09 at 09 39 44](https://cloud.githubusercontent.com/assets/151272/15107883/8abfd00e-15ca-11e6-81a8-e498e3c029ca.png)
