### PR TITLE
Update for 0.17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ node_modules
 
 # Elm stuff
 elm-stuff
+
+test/fixtures/index.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ addons:
 
 env:
   matrix:
-    - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=node
-    - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=0.12
+    - ELM_VERSION=0.17.0 TARGET_NODE_VERSION=node
+    - ELM_VERSION=0.17.0 TARGET_NODE_VERSION=0.12
 
 before_install:
   - if [ ${TRAVIS_OS_NAME} == "osx" ];

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Wraps [Elm](https://elm-lang.org) and exposes a [Node](https://nodejs.org) API to compile Elm sources.
 
-Supports Elm versions 0.15 - 0.16
+Supports Elm version 0.17
 
 # Example
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  ELM_VERSION: "0.16.0"
+  ELM_VERSION: "0.17.0"
   matrix:
   - nodejs_version: "5.0"
   - nodejs_version: "0.12"

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "authors": [
     "Richard Feldman <richard.t.feldman@gmail.com>"
   ],
-  "description": "A Node.js interface to the Elm compiler binaries. Supports Elm versions 0.15 - 0.16.",
+  "description": "A Node.js interface to the Elm compiler binaries. Supports Elm version 0.17",
   "main": "index.js",
   "keywords": [
     "elm",

--- a/examples/HelloWorld.elm
+++ b/examples/HelloWorld.elm
@@ -1,5 +1,5 @@
-import Graphics.Element exposing (..)
+import Html exposing
 
-main : Element
+main : Html
 main =
-  show "Hello, World!"
+  Html.text "Hello, World!"

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -8,7 +8,8 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 4.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-elm-compiler",
   "version": "3.0.0",
-  "description": "A Node.js interface to the Elm compiler binaries. Supports Elm versions 0.15 - 0.16.",
+  "description": "A Node.js interface to the Elm compiler binaries. Supports Elm version 0.17",
   "main": "index.js",
   "scripts": {
     "test": "mocha test/*.js"

--- a/test/compile.js
+++ b/test/compile.js
@@ -93,7 +93,7 @@ describe("#compileToString", function() {
       expect(err).to.be.an('error');
       expect(String(err))
         .to.contain("Compilation failed")
-        .and.contain("I ran into something unexpected when parsing your code!");
+        .and.contain("SYNTAX PROBLEM");
     });
   });
 
@@ -109,7 +109,7 @@ describe("#compileToString", function() {
       expect(err).to.be.an('error');
       expect(String(err))
         .to.contain("Compilation failed")
-        .and.contain("is causing a type mismatch");
+        .and.contain("TYPE MISMATCH");
     });
   });
 

--- a/test/fixtures/Bad.elm
+++ b/test/fixtures/Bad.elm
@@ -1,7 +1,5 @@
-module Bad (..) where
-
-import Graphics.Element exposing (show)
+module Bad
 
 
 main =
-    show "Hello, World!
+   hello! I am a syntax error! :D

--- a/test/fixtures/Parent.elm
+++ b/test/fixtures/Parent.elm
@@ -1,4 +1,4 @@
-module Parent (..) where
+module Parent exposing (..)
 
 import Test.ChildA
 
@@ -7,8 +7,8 @@ import Test.ChildA
 
 import Test.ChildB exposing (..)
 import Native.Child exposing (..)
-import Graphics.Element exposing (show)
+import Html
 
 
 main =
-    show "Hello, World!"
+    Html.text "Hello, World!"

--- a/test/fixtures/ParentWithNestedDeps.elm
+++ b/test/fixtures/ParentWithNestedDeps.elm
@@ -1,4 +1,4 @@
-module Parent (..) where
+module Parent exposing (..)
 
 import Test.ChildA
 

--- a/test/fixtures/Test/ChildA.elm
+++ b/test/fixtures/Test/ChildA.elm
@@ -1,7 +1,7 @@
-module Test.ChildA (..) where
+module Test.ChildA exposing (..)
 
-import Graphics.Element exposing (show)
+import Html
 
 
 main =
-    show "I am child A"
+    Html.text "I am child A"

--- a/test/fixtures/Test/ChildB.elm
+++ b/test/fixtures/Test/ChildB.elm
@@ -1,7 +1,7 @@
-module Test.ChildB (..) where
+module Test.ChildB exposing (..)
 
-import Graphics.Element exposing (show)
+import Html
 
 
 main =
-    show "I am child B"
+    Html.text "I am child B"

--- a/test/fixtures/Test/Sample/NestedChild.elm
+++ b/test/fixtures/Test/Sample/NestedChild.elm
@@ -1,4 +1,4 @@
-module Test.Sample.NestedChild (..) where
+module Test.Sample.NestedChild exposing (..)
 
 import Test.ChildB
 import Native.Child exposing (..)

--- a/test/fixtures/TypeError.elm
+++ b/test/fixtures/TypeError.elm
@@ -1,7 +1,7 @@
-module TypeError (..) where
+module TypeError exposing (..)
 
-import Graphics.Element exposing (show)
+import Html
 
 
 main =
-  show (1 ++ "2")
+    Html.text (1 ++ "2")

--- a/test/fixtures/elm-package.json
+++ b/test/fixtures/elm-package.json
@@ -9,7 +9,8 @@
     "native-modules": true,
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
Now all tests run 0.17 code. Descriptions no longer claim to support 0.15 or 0.16, although in practice they will probably still work fine.