### PR TITLE
Optimized dependency resolver

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,23 +71,49 @@ function compile(sources, options) {
 // Returns a Promise that returns a flat list of all the Elm files the given
 // Elm file depends on, based on the modules it loads via `import`.
 function findAllDependencies(file, knownDependencies, baseDir) {
-  if (!knownDependencies) {
-    knownDependencies = [];
-  }
-
   if (!baseDir) {
     baseDir = path.dirname(file);
   }
 
-  return new Promise(function(resolve, reject) {
+  return findAllDependenciesInternal(knownDependencies, baseDir, [file]);
+}
 
+function findAllDependenciesInternal(knownDependencies, baseDir, unresolvedDependencies) {
+  // We take first unresolved dependency, mark it as resolved, and add all nested
+  // deps to unresolved.
+  if (!knownDependencies) {
+    knownDependencies = [];
+  }
+
+  if (!unresolvedDependencies || _.isEmpty(unresolvedDependencies)) {
+    return knownDependencies;
+  }
+
+  var file = unresolvedDependencies[0];
+
+  if (path.extname(file) !== ".elm") {
+    return findAllDependenciesInternal(_.concat(knownDependencies, [file]), baseDir, _.drop(unresolvedDependencies));
+  }
+
+  return fileImports(file, baseDir).then(filterValidImports).then(function(nestedDeps) {
+    var compactedDeps = _.compact(_.flatten(nestedDeps));
+    var newNested = _.difference(compactedDeps, knownDependencies);
+    var newDependencies = _.concat(knownDependencies, [file]);
+    var newUnresolved = _.uniq(_.concat(_.drop(unresolvedDependencies), newNested));
+
+    return findAllDependenciesInternal(newDependencies, baseDir, newUnresolved);
+  });
+}
+
+function fileImports(file, baseDir) {
+  return new Promise(function (resolve, reject) {
     fs.readFile(file, {encoding: "utf8"}, function(err, lines) {
       if (err) {
         reject(err);
       } else {
         // Turn e.g. ~/code/elm-css/src/Css.elm
         // into just ~/code/elm-css/src/
-        var newImports = _.compact(lines.split("\n").map(function(line) {
+        resolve(_.compact(lines.split("\n").map(function(line) {
           var matches = line.match(/^import\s+([^\s]+)/);
 
           if (matches) {
@@ -98,52 +124,40 @@ function findAllDependencies(file, knownDependencies, baseDir) {
             var dependencyLogicalName = moduleName.replace(/\./g, "/");
 
             // e.g. ~/code/elm-css/src/Css/Declarations.elm
-            var result = path.join(baseDir, dependencyLogicalName)
-
-            return _.includes(knownDependencies, result) ? null : result;
+            return path.join(baseDir, dependencyLogicalName)
           } else {
             return null;
           }
-        }));
-
-        var promises = newImports.map(function(newImport) {
-          var elmFile = newImport + ".elm";
-
-          return new Promise(function(resolve, reject) {
-            return checkIsFile(newImport + ".elm").then(resolve).catch(function(firstErr) {
-              if (firstErr.code === "ENOENT") {
-                // If we couldn't find the import as a .elm file, try as .js
-                checkIsFile(newImport + ".js").then(resolve).catch(function(secondErr) {
-                  if (secondErr.code === "ENOENT") {
-                    // If we don't find the dependency in our filesystem, assume it's because
-                    // it comes in through a third-party package rather than our sources.
-                    resolve([]);
-                  } else {
-                    reject(secondErr);
-                  }
-                })
-              } else {
-                reject(firstErr);
-              }
-            });
-          });
-        });
-
-        Promise.all(promises).then(function(nestedValidDependencies) {
-          var validDependencies = _.flatten(nestedValidDependencies);
-          var newDependencies = knownDependencies.concat(validDependencies);
-          var recursePromises = _.compact(validDependencies.map(function(dependency) {
-            return path.extname(dependency) === ".elm" ?
-              findAllDependencies(dependency, newDependencies, baseDir) : null;
-          }));
-
-          Promise.all(recursePromises).then(function(extraDependencies) {
-            resolve(_.uniq(_.flatten(newDependencies.concat(extraDependencies))));
-          }).catch(reject);
-        }).catch(reject);
-      }
+        })));
+      };
     });
   });
+}
+
+function filterValidImports(newImports) {
+  var promises = newImports.map(function(newImport) {
+    var elmFile = newImport + ".elm";
+
+    return new Promise(function(resolve, reject) {
+      return checkIsFile(newImport + ".elm").then(resolve).catch(function(firstErr) {
+        if (firstErr.code === "ENOENT") {
+          // If we couldn't find the import as a .elm file, try as .js
+          checkIsFile(newImport + ".js").then(resolve).catch(function(secondErr) {
+            if (secondErr.code === "ENOENT") {
+              // If we don't find the dependency in our filesystem, assume it's because
+              // it comes in through a third-party package rather than our sources.
+              resolve([]);
+            } else {
+              reject(secondErr);
+            }
+          })
+        } else {
+          reject(firstErr);
+        }
+      });
+    });
+  });
+  return Promise.all(promises);
 }
 
 // write compiled Elm to a string output

--- a/index.js
+++ b/index.js
@@ -75,7 +75,11 @@ function findAllDependencies(file, knownDependencies, baseDir) {
     baseDir = path.dirname(file);
   }
 
-  return findAllDependenciesInternal(knownDependencies, baseDir, [file]);
+  return findAllDependenciesInternal(knownDependencies, baseDir, [file]).then(function (result) {
+    // We know that very first entry in results is the file itself.
+    // It's not very convenient to have it there, so we simply drop it.
+    return _.drop(result);
+  });
 }
 
 function findAllDependenciesInternal(knownDependencies, baseDir, unresolvedDependencies) {


### PR DESCRIPTION
Current version of dependency resolver is too lazy filtering duplicate imports.

Consider the following dependency graph:

`A -> [B -> [D, E], C -> [D, F]]`

Current implementation would visit file D twice - first when resolving dependencies of B, then when resolving dependencies of C. If D itself contains other dependencies, all of them will also be visited multiple times only to be filtered out when merging B and C's deps.

On my project with only 41 Elm files, this already gets very slow.

This pull request changes the algorithm to linearize dependency graph traversal and filter out duplicates on every step, which guarantees that every source file will be visited only once.