### PR TITLE
Log elm-make output in verbose mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,6 +179,8 @@ function compileToString(sources, options){
           if (exitCode !== 0) {
             temp.cleanupSync();
             return reject(new Error('Compilation failed\n' + output));
+          } else if (options.verbose) {
+            console.log(output)
           }
 
           fs.readFile(info.path, function(err, data){


### PR DESCRIPTION
The main benefit of this change is that the `elm-make` warnings can be seen when both `warn` and `verbose` options are set to true.