### PR TITLE
add failing test for most basic hello world app

### DIFF
--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -9,6 +9,13 @@ function prependFixturesDir(filename) {
 }
 
 describe("#findAllDependencies", function() {
+
+  it("works for a main file without an explicit module statement", function () {
+    return compiler.findAllDependencies(prependFixturesDir("SimplestMain.elm")).then(function(results) {
+      expect(results).to.deep.equal([])
+    });
+  });
+
   it("works for a file with three dependencies", function () {
     return compiler.findAllDependencies(prependFixturesDir("Parent.elm")).then(function(results) {
       expect(results).to.deep.equal(

--- a/test/fixtures/SimplestMain.elm
+++ b/test/fixtures/SimplestMain.elm
@@ -1,0 +1,4 @@
+import Html
+
+main =
+    Html.text "Hello, World!"


### PR DESCRIPTION
The `getBaseDir` function fails for main elm files that do not have an explicit module statement in the first line, such as the most basic possible hello world program.

The failing test results in the following error being thrown:
```
  1) #findAllDependencies works for a main file without an explicit module statement:
     Error: the string "/home/michael/code/bugfix/node-elm-compiler/test/fixtures/SimplestMain.elm is not a syntactically valid Elm module. Try running elm-make on it manually to figure out what the problem is." was thrown, throw an Error :)
```

The contents of SimplestMain.elm is
```
import Html

main =
    Html.text "Hello, World!"
```

This is clearly a valid Elm program, and running elm-make on it manually will succeed.

I arrived at this issue by following the source from elm-webpack-loader.
https://github.com/rtfeldman/elm-webpack-loader/blob/555334261b1263f2cc43e14b0b708b80774d84b0/index.js#L45, calls findAllDependencies from "node-elm-compiler": "4.1.1", and does not specific the baseDir argument. Thus, findAllDependencies tries to figure out the baseDir but fails on the the hello world program as it expects a first line containing "module".

The follow on effect when used with elm-webpack-loader is that the program will compile the first time successfully, but any changes to dependent files are not picked up by the watch functionality of webpack.

I'm not sure if the problem should be solved in elm-webpack-loader (should it be passing a baseDir argument?).

This might be the problem that OP is seeing in elm-webpack-starter: https://github.com/moarwick/elm-webpack-starter/issues/27

