### PR TITLE
Use source-directories during dependency search

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function compile(sources, options) {
       .on('error', function(err) {
         handleError(pathToMake, err);
 
-        process.exit(1)
+        process.exit(1);
       });
   } catch (err) {
     if ((typeof err === "object") && (typeof err.code === "string")) {
@@ -65,7 +65,7 @@ function compile(sources, options) {
       console.error("Exception thrown when attempting to run Elm compiler " + JSON.stringify(pathToMake) + ":\n" + err);
     }
 
-    process.exit(1)
+    process.exit(1);
   }
 }
 
@@ -104,6 +104,40 @@ function getBaseDir(file) {
   });
 }
 
+// Returns the array of source-directories defined in elm-package.json
+function getSourceDirectories(dir) {
+  return new Promise(function(resolve) {
+    var elmPackageFileName = path.join(dir, "elm-package.json");
+
+    // use current directory as only "source-directories" entry when search for elm-package.json fails
+    var currentDirectoryOnly = ["."];
+
+    fs.readFile(elmPackageFileName, {encoding: "utf8"}, function(err, rawData) {
+      if (err) {
+        if(err.code === "ENOENT") {
+          // try parent folder
+          getSourceDirectories(path.normalize(dir + "/..")).then(resolve);
+        } else {
+          resolve(currentDirectoryOnly);
+        }
+      } else {
+        try {
+          var elmPackage = JSON.parse(rawData);
+
+          if(!elmPackage || !elmPackage["source-directories"]) {
+            resolve(currentDirectoryOnly);
+          } else {
+            resolve(elmPackage["source-directories"]);
+          }
+        } catch (err) {
+          console.info("No source-directories will be used as unable to read elm-package.json: " + elmPackageFileName);
+          resolve(currentDirectoryOnly);
+        }
+      }
+    });
+  });
+}
+
 // Returns a Promise that returns a flat list of all the Elm files the given
 // Elm file depends on, based on the modules it loads via `import`.
 function findAllDependencies(file, knownDependencies, baseDir) {
@@ -111,16 +145,20 @@ function findAllDependencies(file, knownDependencies, baseDir) {
     knownDependencies = [];
   }
 
-  if (baseDir) {
-    return findAllDependenciesHelp(file, knownDependencies, baseDir);
-  } else {
-    return getBaseDir(file).then(function(newBaseDir) {
-      return findAllDependenciesHelp(file, knownDependencies, newBaseDir);
+  var helper = function(newBaseDir) {
+    return getSourceDirectories(path.dirname(file)).then(function(sourceDirectories) {
+      return findAllDependenciesHelp(file, knownDependencies, newBaseDir, sourceDirectories)
     });
+  };
+
+  if (baseDir) {
+    return helper(baseDir);
+  } else {
+    return getBaseDir(file).then(helper);
   }
 }
 
-function findAllDependenciesHelp(file, knownDependencies, baseDir) {
+function findAllDependenciesHelp(file, knownDependencies, baseDir, sourceDirectories) {
   return new Promise(function(resolve, reject) {
     fs.readFile(file, {encoding: "utf8"}, function(err, lines) {
       if (err) {
@@ -141,33 +179,14 @@ function findAllDependenciesHelp(file, knownDependencies, baseDir) {
             // e.g. ~/code/elm-css/src/Css/Declarations.elm
             var result = path.join(baseDir, dependencyLogicalName)
 
-            return _.includes(knownDependencies, result) ? null : result;
+            return _.includes(knownDependencies, result) ? null : dependencyLogicalName;
           } else {
             return null;
           }
         }));
 
         var promises = newImports.map(function(newImport) {
-          var elmFile = newImport + ".elm";
-
-          return new Promise(function(resolve, reject) {
-            return checkIsFile(newImport + ".elm").then(resolve).catch(function(firstErr) {
-              if (firstErr.code === "ENOENT") {
-                // If we couldn't find the import as a .elm file, try as .js
-                checkIsFile(newImport + ".js").then(resolve).catch(function(secondErr) {
-                  if (secondErr.code === "ENOENT") {
-                    // If we don't find the dependency in our filesystem, assume it's because
-                    // it comes in through a third-party package rather than our sources.
-                    resolve([]);
-                  } else {
-                    reject(secondErr);
-                  }
-                })
-              } else {
-                reject(firstErr);
-              }
-            });
-          });
+          return findDependency(baseDir, sourceDirectories, newImport);
         });
 
         Promise.all(promises).then(function(nestedValidDependencies) {
@@ -175,7 +194,7 @@ function findAllDependenciesHelp(file, knownDependencies, baseDir) {
           var newDependencies = knownDependencies.concat(validDependencies);
           var recursePromises = _.compact(validDependencies.map(function(dependency) {
             return path.extname(dependency) === ".elm" ?
-              findAllDependenciesHelp(dependency, newDependencies, baseDir) : null;
+              findAllDependenciesHelp(dependency, newDependencies, baseDir, sourceDirectories) : null;
           }));
 
           Promise.all(recursePromises).then(function(extraDependencies) {
@@ -184,6 +203,34 @@ function findAllDependenciesHelp(file, knownDependencies, baseDir) {
         }).catch(reject);
       }
     });
+  });
+}
+
+function findDependency(baseDir, sourceDirectories, newImport) {
+  return new Promise(function(resolve, reject) {
+    var checker = function(file, nextCheck) {
+      return checkIsFile(file).then(resolve).catch(function(err) {
+        if (err.code === "ENOENT") {
+          nextCheck();
+        } else {
+          reject(err);
+        }
+      });
+    };
+
+    var dependencyChecker = _.reduce(sourceDirectories, function (nextCheck, sourceDir) {
+      return function() {
+        return checker(path.join(baseDir, sourceDir, newImport + ".elm"), function () {
+          checker(path.join(baseDir, sourceDir, newImport + ".js"), nextCheck);
+        });
+      };
+    }, function() {
+      // If we don't find the dependency in our filesystem, assume it's because
+      // it comes in through a third-party package rather than our sources.
+      resolve([]);
+    });
+
+    return dependencyChecker();
   });
 }
 
@@ -204,7 +251,7 @@ function compileToString(sources, options){
       }
 
       options.output = info.path;
-      options.processOpts = { stdio: 'pipe' }
+      options.processOpts = { stdio: 'pipe' };
 
       var compiler = compile(sources, options);
 
@@ -252,7 +299,7 @@ function checkIsFile(file) {
 
 function handleError(pathToMake, err) {
   if (err.code === "ENOENT") {
-    console.error("Could not find Elm compiler \"" + pathToMake + "\". Is it installed?")
+    console.error("Could not find Elm compiler \"" + pathToMake + "\". Is it installed?");
   } else if (err.code === "EACCES") {
     console.error("Elm compiler \"" + pathToMake + "\" did not have permission to run. Do you need to give it executable permissions?");
   } else {

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -2,11 +2,15 @@ var expect = require("chai").expect;
 var path = require("path");
 var compiler = require(path.join(__dirname, ".."));
 
-var fixturesDir = path.join(__dirname, "fixtures");
-
-function prependFixturesDir(filename) {
-  return path.join(fixturesDir, filename);
+function prependDir(fixtureDir) {
+  return function(filename) {
+    var fixturesDir = path.join(__dirname, fixtureDir);
+    return path.join(fixturesDir, filename);
+  }
 }
+
+var prependFixturesDir = prependDir("fixtures");
+var prependMoreFixturesDir = prependDir("moreFixtures");
 
 describe("#findAllDependencies", function() {
 
@@ -37,6 +41,14 @@ describe("#findAllDependencies", function() {
         path.join("Nested", "Parent", "Test.elm"))).then(function(results) {
       expect(results).to.deep.equal(
         [ "Test/ChildA.elm", "Nested/Child.elm", "Nested/Test/Child.elm", "Test/Sample/NestedChild.elm", "Test/ChildB.elm", "Native/Child.js" ].map(prependFixturesDir)
+      );
+    });
+  });
+
+  it("works for a file with dependencies defined via source-directories in elm-package.json", function () {
+    return compiler.findAllDependencies(prependFixturesDir("ParentWithSourceDirectoriesDeps.elm")).then(function(results) {
+      expect(results).to.deep.equal(
+          [ "Sibling.elm", "AnotherTest/Cousin.elm" ].map(prependMoreFixturesDir)
       );
     });
   });

--- a/test/fixtures/ParentWithSourceDirectoriesDeps.elm
+++ b/test/fixtures/ParentWithSourceDirectoriesDeps.elm
@@ -1,0 +1,10 @@
+module ParentWithSourceDirectoriesDeps exposing (..)
+
+import Sibling
+import AnotherTest.Cousin
+
+import Html
+
+
+main =
+    Html.text "Hello, World!"

--- a/test/fixtures/elm-package.json
+++ b/test/fixtures/elm-package.json
@@ -4,7 +4,8 @@
     "repository": "https://github.com/foo/bar.git",
     "license": "BSD3",
     "source-directories": [
-        "."
+        ".",
+        "../moreFixtures"
     ],
     "native-modules": true,
     "exposed-modules": [],

--- a/test/moreFixtures/AnotherTest/Cousin.elm
+++ b/test/moreFixtures/AnotherTest/Cousin.elm
@@ -1,0 +1,7 @@
+module AnotherTest.Cousin exposing (..)
+
+import Html
+
+
+main =
+    Html.text "I am a cousin"

--- a/test/moreFixtures/Sibling.elm
+++ b/test/moreFixtures/Sibling.elm
@@ -1,0 +1,7 @@
+module Sibling exposing (..)
+
+import Html
+
+
+main =
+    Html.text "I am a sibling"


### PR DESCRIPTION
While trying to setup webpack to continuously re-run tests using the html-test-runner I found that the dependencies in the main elm app were not being tracked. Which caused the tests to not re-run when they changed.

I believe the directory structure that the doc's for elm-test advise is:

```
app
   elm-package.json (for app)
   elm-stuff
         ....
   src
        Main.elm
        Widget.elm
   tests
        elm-package.json (for tests)
        elm-stuff
            ...
        WidgetTest.elm
```

As a result in the code for this PR I have tried to add a search for elm-package.json, so that the source directories can be extracted. These are then used when searching for the dependant modules, such that it now treats code in the src directory as part of the application - previously it was ignoring them as if they were 3rd party components in elm-stuff.
