### PR TITLE
Allow for elm-make 0.18 to be run in debug mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var defaultOptions     = {
   emitWarning: console.warn,
   spawn:      spawn,
   cwd:        undefined,
+  debug:      undefined,
   pathToMake: undefined,
   yes:        undefined,
   help:       undefined,
@@ -273,6 +274,7 @@ function compilerArgsFromOptions(options, emitWarning) {
         case "output": return ["--output", escapePath(value)];
         case "report": return ["--report", value];
         case "warn":   return ["--warn"];
+        case "debug":   return ["--debug"];
         default:
           if (supportedOptions.indexOf(opt) === -1) {
             emitWarning('Unknown Elm compiler option: ' + opt);


### PR DESCRIPTION
Allows `--debug` to be passed as an option to elm-make 0.18