### PR TITLE
Upgrade to find-elm-dependencies 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/rtfeldman/node-elm-compiler",
   "dependencies": {
     "cross-spawn": "4.0.0",
-    "find-elm-dependencies": "0.18.1",
+    "find-elm-dependencies": "1.0.1",
     "lodash": "4.14.2",
     "temp": "^0.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-elm-compiler",
   "version": "4.3.0",
-  "description": "A Node.js interface to the Elm compiler binaries. Supports Elm version 0.17",
+  "description": "A Node.js interface to the Elm compiler binaries. Supports Elm version 0.17, 0.18",
   "main": "index.js",
   "scripts": {
     "test": "mocha test/*.js"


### PR DESCRIPTION
This enables `node-elm-compiler#findElmDependencies` to correctly report all dependencies within a multi-source-directory project.

We need this for our Webpack build at Culture Amp, so I’m hoping this can be merged and a new version of node-elm-compiler released to NPM soon, so that we can then upgrade https://github.com/elm-community/elm-webpack-loader.

Thanks in advance!