### PR TITLE
Upgrade find-elm-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/rtfeldman/node-elm-compiler",
   "dependencies": {
     "cross-spawn": "4.0.0",
-    "find-elm-dependencies": "1.0.1",
+    "find-elm-dependencies": "1.0.2",
     "lodash": "4.14.2",
     "temp": "^0.8.3"
   },


### PR DESCRIPTION
`1.0.1` -> `1.0.2` - only change is `find-elm-dependencies` added a `.npmignore`