### PR TITLE
Fixed issue when spawn function could not be propagated from the outside world

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function handleCompilerError(err, pathToMake) {
 }
 
 function compileSync(sources, options) {
-  var optionsWithDefaults = prepareOptions(options, spawn.sync);
+  var optionsWithDefaults = prepareOptions(options, options.spawn || spawn.sync);
   var pathToMake = options.pathToMake || compilerBinaryName;
 
   try {
@@ -88,7 +88,7 @@ function compileSync(sources, options) {
 }
 
 function compile(sources, options) {
-  var optionsWithDefaults = prepareOptions(options, spawn);
+  var optionsWithDefaults = prepareOptions(options, options.spawn || spawn);
   var pathToMake = options.pathToMake || compilerBinaryName;
 
 


### PR DESCRIPTION
Hello, grunt-elm module can't propagate spawn function to node-elm-compiler module because it's put into options but it's not get used.

Please see this issue: https://github.com/rtfeldman/grunt-elm/issues/14