### PR TITLE
Add compileToStringSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,6 +151,18 @@ function compileToString(sources, options){
   });
 }
 
+function compileToStringSync(sources, options) {
+  if (typeof options.output === "undefined"){
+    options.output = '.js';
+  }
+
+  const file = temp.openSync({ suffix: options.output });
+  options.output = file.path;
+  compileSync(sources, options);
+
+  return fs.readFileSync(file.path, {encoding: "utf8"});
+}
+
 function handleError(pathToMake, err) {
   if (err.code === "ENOENT") {
     console.error("Could not find Elm compiler \"" + pathToMake + "\". Is it installed?")
@@ -191,5 +203,6 @@ module.exports = {
   compileSync: compileSync,
   compileWorker: require("./worker.js")(compile),
   compileToString: compileToString,
+  compileToStringSync: compileToStringSync,
   findAllDependencies: findAllDependencies
 };

--- a/test/compileToStringSync.js
+++ b/test/compileToStringSync.js
@@ -1,0 +1,32 @@
+var chai = require("chai");
+// var spies = require("chia-spies");
+var path = require("path");
+var compiler = require(path.join(__dirname, ".."));
+
+var expect = chai.expect;
+
+var fixturesDir = path.join(__dirname, "fixtures");
+
+function prependFixturesDir(filename) {
+  return path.join(fixturesDir, filename);
+}
+
+describe("#compileToStringSync", function() {
+  it('returns string JS output of the given elm file', function() {
+    var opts = {yes: true, verbose: true, cwd: fixturesDir};
+    var result = compiler.compileToStringSync(prependFixturesDir("Parent.elm"), opts);
+
+    expect(result).to.include("globalElm[publicModule] = Elm[publicModule];");
+    expect(result).to.include("Elm['Parent'] = Elm['Parent'] || {}");
+  });
+
+  it('returns html output given "html" output option', function() {
+    var opts = {yes: true, verbose: true, cwd: fixturesDir, output: '.html'};
+    var result = compiler.compileToStringSync(prependFixturesDir("Parent.elm"), opts);
+
+    expect(result).to.include('<!DOCTYPE HTML>');
+    expect(result).to.include('<title>Parent</title>');
+    expect(result).to.include("globalElm[publicModule] = Elm[publicModule];");
+    expect(result).to.include("Elm['Parent'] = Elm['Parent'] || {}");
+  });
+});


### PR DESCRIPTION
This adds a new helper `compileToStringSync` and closes #60. Some
use-cases, such as Jest, require a synchronous compilation step, so this
allows Elm code to be compiled synchronously to a string.