### PR TITLE
Add a way to look up where the elm binaries are

### DIFF
--- a/examples/compileHelloWorld.js
+++ b/examples/compileHelloWorld.js
@@ -1,6 +1,14 @@
 var compile = require("../index.js").compile;
 var compileToString = require("../index.js").compileToString;
 
+var findElmBinaries = require("../index.js").findElmBinaries;
+
+findElmBinaries().then(function(foundPath){
+    console.log(foundPath);
+}).catch(function(err){
+    console.log(err);
+});
+
 compile(["./HelloWorld.elm"], {
   output: "compiled-hello-world.js"
 }).on('close', function(exitCode) {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var fs = require("fs");
 var path = require("path");
 var temp = require("temp").track();
 var findAllDependencies = require("find-elm-dependencies").findAllDependencies;
+var which = require("which");
 
 var defaultOptions     = {
   emitWarning: console.warn,
@@ -198,11 +199,30 @@ function compilerArgsFromOptions(options, emitWarning) {
   }));
 }
 
+// Tries to locate where the Elm binaries are. First looks at node_modules, then globally
+//
+function findElmBinaries() {
+  let localElmBin = path.resolve(path.join("node_modules", ".bin", "elm-make"));
+
+  return new Promise(function(resolve, reject) {
+    fs.access(localElmBin, function(err) {
+      if (!err) return resolve(localElmBin);
+
+      which('elm-make', function(err, path) {
+        if (err) return reject("Unable to find Elm anywhere!");
+
+        return resolve(path);
+      });
+    })
+  });
+}
+
 module.exports = {
   compile: compile,
   compileSync: compileSync,
   compileWorker: require("./worker.js")(compile),
   compileToString: compileToString,
   compileToStringSync: compileToStringSync,
-  findAllDependencies: findAllDependencies
+  findAllDependencies: findAllDependencies,
+  findElmBinaries: findElmBinaries
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "cross-spawn": "4.0.0",
     "find-elm-dependencies": "1.0.2",
     "lodash": "4.14.2",
-    "temp": "^0.8.3"
+    "temp": "^0.8.3",
+    "which": "^1.3.0"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
This is used in a few projects, like:

- elm-test https://github.com/rtfeldman/node-test-runner/blob/87d8aa1b2805914da8f64e4005e5bf6ff9f8e06f/lib/elm-test.js#L90
- elm-benchmark https://github.com/BrianHicks/elm-benchmark/blob/master/cli/elm-benchmark.js#L63

Likewise, it should probably be used in elm-webpack-loader and similar tools, since generally the expected behaviour for these tools is to use the locally installed (node_modules) over the global