### PR TITLE
Add support for +RTS/-RTS flags from GHC

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,6 +187,7 @@ function compilerArgsFromOptions(options, emitWarning) {
         case "warn":   return ["--warn"];
         case "debug":  return ["--debug"];
         case "docs":   return ["--docs", value]
+        case "runtimeOptions":   return ["+RTS", value, "-RTS"]
         default:
           if (supportedOptions.indexOf(opt) === -1) {
             emitWarning('Unknown Elm compiler option: ' + opt);
@@ -206,5 +207,6 @@ module.exports = {
   compileWorker: require("./worker.js")(compile),
   compileToString: compileToString,
   compileToStringSync: compileToStringSync,
-  findAllDependencies: findAllDependencies
+  findAllDependencies: findAllDependencies,
+  _prepareProcessArgs: prepareProcessArgs
 };

--- a/test/compile.js
+++ b/test/compile.js
@@ -82,6 +82,19 @@ describe("#compileToString", function() {
     });
   });
 
+  it("adds runtime options as arguments", function () {
+    var opts = {
+      yes: true,
+      verbose: true,
+      cwd: fixturesDir,
+      runtimeOptions: "-A128M -H128M -n8m"
+    };
+
+    return expect(compiler
+        ._prepareProcessArgs("a.elm", opts)
+        .join(" ")).to.equal("a.elm --yes +RTS -A128M -H128M -n8m -RTS");
+  });
+
   it("reports errors on bad syntax", function () {
     var opts = {
       yes: true,


### PR DESCRIPTION
Enabling these flags allows for tuning the GHC runtime and can dramatically improve build times when a lot of files have to be recompiled, as well as improving performance on large `case` statements, the main benefit is reducing the time spent in the garbage collector.

This does require a version of `elm-make` compiled with the `-rtsopts` option to allow [runtime control](https://downloads.haskell.org/~ghc/7.10.1/docs/html/users_guide/runtime-control.html), if you try to run it on a version without that enabled you'll get the message:

```
$ elm-make src/elm/Main.elm +RTS -A128M -N128M -n8m -RTS
elm-make.exe: Most RTS options are disabled. Link with -rtsopts to enable them.
```

Some further information and related issues here:
- https://github.com/elm-lang/elm-make/issues/159#issuecomment-318850631
- https://discourse.elm-lang.org/t/repos-with-slow-compile-times-wanted-for-research/662
- https://github.com/elm-lang/elm-make/pull/179

The current version of elm-make does allow limited RTS options, for instance, you can use `+RTS -s -RTS` to profile a run.