### PR TITLE
Fix rts rts flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ function compilerArgsFromOptions(options, emitWarning) {
         case "warn":   return ["--warn"];
         case "debug":  return ["--debug"];
         case "docs":   return ["--docs", value]
-        case "runtimeOptions":   return ["+RTS", value, "-RTS"]
+        case "runtimeOptions":   return [].concat(["+RTS"], value ,["-RTS"])
         default:
           if (supportedOptions.indexOf(opt) === -1) {
             emitWarning('Unknown Elm compiler option: ' + opt);

--- a/test/compile.js
+++ b/test/compile.js
@@ -87,7 +87,7 @@ describe("#compileToString", function() {
       yes: true,
       verbose: true,
       cwd: fixturesDir,
-      runtimeOptions: "-A128M -H128M -n8m"
+      runtimeOptions: ["-A128M", "-H128M", "-n8m"]
     };
 
     return expect(compiler


### PR DESCRIPTION
以前の引数の渡し方では、意図通りにelm-makeが動作しませんでした。

↓ english from google
In the previous method of passing arguments, elm-make did not work as intended.
