### PR TITLE
Support Elm 0.19's --optimize flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,11 +15,11 @@ var defaultOptions     = {
   help:       undefined,
   output:     undefined,
   report:     undefined,
-  warn:       undefined,
   debug:      undefined,
   verbose:    false,
   processOpts: undefined,
   docs:       undefined,
+  optimize:   undefined,
 };
 
 var supportedOptions = _.keys(defaultOptions);
@@ -179,9 +179,9 @@ function compilerArgsFromOptions(options) {
         case "help":   return ["--help"];
         case "output": return ["--output", value];
         case "report": return ["--report", value];
-        case "warn":   return ["--warn"];
         case "debug":  return ["--debug"];
         case "docs":   return ["--docs", value]
+        case "optimize":   return ["--optimize"];
         case "runtimeOptions":   return ["+RTS", value, "-RTS"]
         default:
           if (supportedOptions.indexOf(opt) === -1) {


### PR DESCRIPTION
Hi,

I made a small modification for adding support for the new `--optimize` flag in Elm 0.19 (based on the already existing 0.19 branch on this repo).

I also made a PR on [`find-elm-dependencies`](https://github.com/NoRedInk/find-elm-dependencies/pull/8) that might be necessary to go through before merging this one.

This upgrade is necessary for upgrading [`elm-webpack-loader`](https://github.com/elm-community/elm-webpack-loader) to 0.19 ([See PR #142 there](https://github.com/elm-community/elm-webpack-loader/pull/142)).