### PR TITLE
Make errors from compile() nicer

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function compile(sources, options) {
 
   try {
     return runCompiler(sources, optionsWithDefaults, pathToElm)
-      .on('error', function(err) { throw(err); });
+      .on('error', function(err) { throw compilerErrorToString(err); });
   } catch (err) {
     throw compilerErrorToString(err, pathToElm);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-elm-compiler",
-  "version": "5.0.0-alpha1",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Making errors from `compile()` nicer. I couldn't add a unit test for this because the error is thrown asynchronously and hard to catch.

Also updating the version in `package-lock.json`.

## Before & After

With the following test script:

```js
const compiler = require('.');

var opts = {
  pathToElm: "i-dont-exist",
  verbose: true,
  cwd: '',
};

compiler.compile("Parent.elm", opts);
```

Before:

```
[~/work/elm/node-elm-compiler] (master *) € node test.js
Running i-dont-exist make Parent.elm
/Users/shuhei/work/elm/node-elm-compiler/index.js:103
      .on('error', function(err) { throw (err); });
                                   ^

Error: spawn i-dont-exist ENOENT
    at _errnoException (util.js:992:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:190:19)
    at onErrorNT (internal/child_process.js:372:16)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
    at Function.Module.runMain (module.js:695:11)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:612:3
```

After:

```
[~/work/elm/node-elm-compiler] (master *) € node test.js
Running i-dont-exist make Parent.elm

/Users/shuhei/work/elm/node-elm-compiler/index.js:103
      .on('error', function(err) { throw compilerErrorToString(err); });
                                   ^
Could not find Elm compiler "undefined". Is it installed?
```