### PR TITLE
0.18 security updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-elm-compiler",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "A Node.js interface to the Elm compiler binaries. Supports Elm version 0.17, 0.18",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,14 +26,15 @@
   "homepage": "https://github.com/rtfeldman/node-elm-compiler",
   "dependencies": {
     "cross-spawn": "4.0.0",
-    "find-elm-dependencies": "1.0.2",
-    "lodash": "4.14.2",
+    "elm": "^0.18.0",
+    "find-elm-dependencies": "^1.0.3",
+    "lodash": "4.17.11",
     "temp": "^0.8.3"
   },
   "devDependencies": {
     "chai": "3.5.0",
     "chai-spies": "0.7.1",
     "glob": "7.1.1",
-    "mocha": "3.0.2"
+    "mocha": "5.2.0"
   }
 }


### PR DESCRIPTION
Just trying to resolve npm security warnings.

Obviously this branch can't be merged into master, but could we maybe ....
- pull off a 0.18 branch
- release a new 4.x version

<3<3<3