### PR TITLE
Test compiled output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,31 @@
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.0.tgz",
@@ -264,6 +289,18 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
@@ -405,6 +442,39 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -486,6 +556,15 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
       "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
       "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "yn": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "prepack": "npm run build",
     "build": "rm -rf dist/ & tsc",
-    "test": "rm -rf test/fixtures/elm-stuff & npm run build & mocha test/**/*.ts --require ts-node/register --watch-extensions ts"
+    "test": "npm run build & npm run runTests",
+    "runTests": "rm -rf test/fixtures/elm-stuff & mocha test/**/*.ts --require ts-node/register --watch-extensions ts",
+    "test:dev": "cross-env NODE_TEST='dev' npm run runTests"
   },
   "repository": {
     "type": "git",
@@ -36,6 +38,7 @@
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.15",
     "chai": "3.5.0",
+    "cross-env": "^5.2.0",
     "glob": "7.1.1",
     "mocha": "5.1.1",
     "ts-node": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "dist/index.js",
   "scripts": {
     "prepack": "npm run build",
-    "build": "rm -rf dist/ & tsc",
-    "test": "npm run build & npm run runTests",
-    "runTests": "rm -rf test/fixtures/elm-stuff & mocha test/**/*.ts --require ts-node/register --watch-extensions ts",
+    "build": "rm -rf dist/ && tsc",
+    "test": "npm run build && npm run runTests",
+    "runTests": "rm -rf test/fixtures/elm-stuff && mocha test/**/*.ts --require ts-node/register --watch-extensions ts",
     "test:watch": "cross-env NODE_TEST='dev' npm run runTests -- --watch"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "rm -rf dist/ & tsc",
     "test": "npm run build & npm run runTests",
     "runTests": "rm -rf test/fixtures/elm-stuff & mocha test/**/*.ts --require ts-node/register --watch-extensions ts",
-    "test:dev": "cross-env NODE_TEST='dev' npm run runTests"
+    "test:watch": "cross-env NODE_TEST='dev' npm run runTests -- --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "prepack": "npm run build",
-    "build": "rm -rf dist/ && tsc",
-    "test": "rm -rf test/fixtures/elm-stuff && mocha test/**/*.ts --require ts-node/register --watch-extensions ts"
+    "build": "rm -rf dist/ & tsc",
+    "test": "rm -rf test/fixtures/elm-stuff & npm run build & mocha test/**/*.ts --require ts-node/register --watch-extensions ts"
   },
   "repository": {
     "type": "git",

--- a/test/compile.ts
+++ b/test/compile.ts
@@ -1,6 +1,6 @@
 var chai = require("chai")
 var path = require("path");
-var compiler = require(path.join(__dirname, "../src"));
+var compiler = require(path.join(__dirname, ".."));
 var childProcess = require("child_process");
 var _ = require("lodash");
 var temp = require("temp");

--- a/test/compile.ts
+++ b/test/compile.ts
@@ -1,6 +1,6 @@
 var chai = require("chai")
 var path = require("path");
-var compiler = require(path.join(__dirname, ".."));
+var compiler = require(path.join(__dirname, "..", process.env["NODE_TEST"] == "dev" ? "src" : ""));
 var childProcess = require("child_process");
 var _ = require("lodash");
 var temp = require("temp");

--- a/test/compileSync.ts
+++ b/test/compileSync.ts
@@ -1,6 +1,6 @@
 var chai = require("chai")
 var path = require("path");
-var compiler = require(path.join(__dirname, "../src"));
+var compiler = require(path.join(__dirname, ".."));
 
 var expect = chai.expect;
 

--- a/test/compileSync.ts
+++ b/test/compileSync.ts
@@ -1,6 +1,6 @@
 var chai = require("chai")
 var path = require("path");
-var compiler = require(path.join(__dirname, ".."));
+var compiler = require(path.join(__dirname, "..", process.env["NODE_TEST"] == "dev" ? "src" : ""));
 
 var expect = chai.expect;
 

--- a/test/compileToStringSync.ts
+++ b/test/compileToStringSync.ts
@@ -1,6 +1,6 @@
 var chai = require("chai");
 var path = require("path");
-var compiler = require(path.join(__dirname, "../src"));
+var compiler = require(path.join(__dirname, ".."));
 
 var expect = chai.expect;
 

--- a/test/compileToStringSync.ts
+++ b/test/compileToStringSync.ts
@@ -1,6 +1,6 @@
 var chai = require("chai");
 var path = require("path");
-var compiler = require(path.join(__dirname, ".."));
+var compiler = require(path.join(__dirname, "..", process.env["NODE_TEST"] == "dev" ? "src" : ""));
 
 var expect = chai.expect;
 


### PR DESCRIPTION
Instead of only testing the source files, test the compiled files that will be published and their integration in `package.json`.

Since changes to the sources will not automatically recompile, this PR adds a `test:watch` script that runs the tests on source (and test) file changes