### PR TITLE
Prevent parallel executions in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "prepack": "npm run build",
-    "build": "rm -rf dist/ & tsc",
-    "test": "rm -rf test/fixtures/elm-stuff & mocha test/**/*.ts --require ts-node/register --watch-extensions ts"
+    "build": "rm -rf dist/ && tsc",
+    "test": "rm -rf test/fixtures/elm-stuff && mocha test/**/*.ts --require ts-node/register --watch-extensions ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Using `&` parallely runs both sides of the command. Using `&&` chains them.