### PR TITLE
Fix suffix handling in output option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ var spawn = require("cross-spawn");
 var _ = require("lodash");
 var elmBinaryName = "elm";
 var fs = require("fs");
+var path = require("path");
 var temp = require("temp").track();
 var findAllDependencies = require("find-elm-dependencies").findAllDependencies;
 
@@ -112,12 +113,13 @@ function compile(sources, options) {
 // output to a html file instead
 // creates a temp file and deletes it after reading
 function compileToString(sources, options) {
-  if (typeof options.output === "undefined") {
-    options.output = '.js';
+  let suffix = '.js';
+  if (options.output) {
+    suffix = path.extname(options.output) || '.js';
   }
 
   return new Promise(function (resolve, reject) {
-    temp.open({ suffix: options.output }, function (err, info) {
+    temp.open({ suffix }, function (err, info) {
       if (err) {
         return reject(err);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,16 +107,21 @@ function compile(sources, options) {
   }
 }
 
+function getSuffix(outputPath, defaultSuffix) {
+  if (outputPath) {
+    return path.extname(outputPath) || defaultSuffix;
+  } else {
+    return defaultSuffix;
+  }
+}
+
 // write compiled Elm to a string output
 // returns a Promise which will contain a Buffer of the text
 // If you want html instead of js, use options object to set
 // output to a html file instead
 // creates a temp file and deletes it after reading
 function compileToString(sources, options) {
-  let suffix = '.js';
-  if (options.output) {
-    suffix = path.extname(options.output) || '.js';
-  }
+  const suffix = getSuffix(options.output, '.js');
 
   return new Promise(function (resolve, reject) {
     temp.open({ suffix }, function (err, info) {
@@ -162,11 +167,9 @@ function compileToString(sources, options) {
 }
 
 function compileToStringSync(sources, options) {
-  if (typeof options.output === "undefined") {
-    options.output = '.js';
-  }
+  const suffix = getSuffix(options.output, '.js');
 
-  const file = temp.openSync({ suffix: options.output });
+  const file = temp.openSync({ suffix });
   options.output = file.path;
   compileSync(sources, options);
 

--- a/test/compile.ts
+++ b/test/compile.ts
@@ -134,6 +134,20 @@ describe("#compileToString", function () {
     }
     return Promise.all(promises);
   });
+
+  it("handles output suffix correctly", function () {
+    var opts = {
+      verbose: true,
+      cwd: fixturesDir,
+      output: prependFixturesDir("compiled.html"),
+    };
+
+    return compiler.compileToString(prependFixturesDir("Parent.elm"), opts)
+      .then(function (result) {
+        var desc = "Expected elm make to return the result of the compilation";
+        expect(result.toString(), desc).to.be.a('string');
+      });
+  });
 });
 
 describe("#compileWorker", function () {

--- a/test/compileToStringSync.ts
+++ b/test/compileToStringSync.ts
@@ -19,7 +19,11 @@ describe("#compileToStringSync", function () {
   });
 
   it('returns html output given "html" output option', function () {
-    var opts = { verbose: true, cwd: fixturesDir, output: '.html' };
+    var opts = {
+      verbose: true,
+      cwd: fixturesDir,
+      output: prependFixturesDir('compiled.html'),
+    };
     var result = compiler.compileToStringSync(prependFixturesDir("Parent.elm"), opts);
 
     expect(result).to.include('<!DOCTYPE HTML>');


### PR DESCRIPTION
`compileToString(Sync)` break when the `options.output` field is a path. They expect only a suffix.

This PR fixes this behavior by accepting paths and extracting the suffix.