### PR TITLE
Add node 12 to CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ os:
 
 env:
   matrix:
-    - ELM_VERSION=0.19.0-bugfix2 TARGET_NODE_VERSION=8.0
-    - ELM_VERSION=0.19.0-bugfix2 TARGET_NODE_VERSION=10.0
-    - ELM_VERSION=0.19.0-bugfix2 TARGET_NODE_VERSION=12.0
+    - ELM_VERSION=0.19.0-no-deps TARGET_NODE_VERSION=8.0
+    - ELM_VERSION=0.19.0-no-deps TARGET_NODE_VERSION=10.0
+    - ELM_VERSION=0.19.0-no-deps TARGET_NODE_VERSION=12.0
 
 before_install:
   - rm -rf ~/.elm

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   matrix:
     - ELM_VERSION=0.19.0-bugfix2 TARGET_NODE_VERSION=8.0
     - ELM_VERSION=0.19.0-bugfix2 TARGET_NODE_VERSION=10.0
+    - ELM_VERSION=0.19.0-bugfix2 TARGET_NODE_VERSION=12.0
 
 before_install:
   - rm -rf ~/.elm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,23 @@
 sudo: false
 
+language: node_js
+node_js:
+  - "8"
+  - "10"
+  - "12"
+
 os:
   - linux
   - osx
 
 env:
   matrix:
-    - ELM_VERSION=0.19.0-no-deps TARGET_NODE_VERSION=8.0
-    - ELM_VERSION=0.19.0-no-deps TARGET_NODE_VERSION=10.0
-    - ELM_VERSION=0.19.0-no-deps TARGET_NODE_VERSION=12.0
+    - ELM_VERSION=0.19.0-no-deps
 
 before_install:
   - rm -rf ~/.elm
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];
-    then brew update; brew install nvm; mkdir ~/.nvm; export NVM_DIR=~/.nvm; source $(brew --prefix nvm)/nvm.sh;
-    fi
 
 install:
-  - nvm install $TARGET_NODE_VERSION
-  - nvm use $TARGET_NODE_VERSION
   - node --version
   - npm --version
   - npm install -g elm@$ELM_VERSION

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ environment:
   - nodejs_version: "8.0"
 
 platform:
-  - x86
   - x64
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  ELM_VERSION: "0.19.0-no-deps"
+  ELM_VERSION: "0.19.0-bugfix6"
   matrix:
   - nodejs_version: "12.0"
   - nodejs_version: "10.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   ELM_VERSION: "0.19.0-bugfix2"
   matrix:
+  - nodejs_version: "12.0"
   - nodejs_version: "10.0"
   - nodejs_version: "8.0"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  ELM_VERSION: "0.19.0-bugfix2"
+  ELM_VERSION: "0.19.0-no-deps"
   matrix:
   - nodejs_version: "12.0"
   - nodejs_version: "10.0"


### PR DESCRIPTION
Notes:

- `elm@0.19.0-bugfix2` doesn't work with node 12
- https://github.com/rtfeldman/node-elm-compiler/pull/98/commits/a634874347dfa0f4fd98454cb4ed360bc1d5767f greatly speeds up MacOS travis builds (cutting them from 5 minutes down to 45 seconds)
- `elm@0.19.0-no-deps` does not appear to provide 32-bit Windows binaries
- `elm@0.19.0-no-deps` fails the "works when run multiple times" test on Windows, so I switched it back down to `elm@0.19.0-bugfix6`