### PR TITLE
compileToStringSync returns empty string on error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-elm-compiler",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "A Node.js interface to the Elm compiler binaries.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,9 +171,15 @@ function compileToStringSync(sources, options) {
 
   const file = temp.openSync({ suffix });
   options.output = file.path;
-  compileSync(sources, options);
+  let compileProcess = compileSync(sources, options);
 
-  return fs.readFileSync(file.path, { encoding: "utf8" });
+  if (compileProcess.status == 0) {
+    return fs.readFileSync(file.path, { encoding: "utf8" });
+  }
+  else {
+    // Throw a simple error. We already let elm output to stdout/stderr
+    throw 'Compilation failed.';
+  }
 }
 
 // Converts an object of key/value pairs to an array of arguments suitable

--- a/test/compileToStringSync.ts
+++ b/test/compileToStringSync.ts
@@ -30,4 +30,11 @@ describe("#compileToStringSync", function () {
     expect(result).to.include('<title>Parent</title>');
     expect(result).to.include("_Platform_export");
   });
+  it('throws on compilation errors', function () {
+    var opts = { verbose: false, cwd: fixturesDir };
+
+    expect(function () {
+      compiler.compileToStringSync(prependFixturesDir("Bad.elm"), opts);
+    }).to.throw();
+  });
 });


### PR DESCRIPTION
I modified https://github.com/phenax/esbuild-plugin-elm/ to use `compileToStringSync` and noticed our tools stopped being able to tell when Elm compilation failed.

Traced it back to us not handling the compiler process exit status on `compileToStringSync`.